### PR TITLE
Added automation script stacklaunch and README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,13 +62,13 @@ This command needs to be made from the reverse-proxy folder, and relies on all o
 
 Example:
 
-InTheBytes
-|---account-service
-|---order-service
-|---search-service
-|---restaurant-manage-service
-|---open-api-since
-|---reverse-proxy (call command here)
+InTheBytes:
+* ---account-service
+* ---order-service
+* ---search-service
+* ---restaurant-manage-service
+* ---open-api-since
+* ---reverse-proxy (call command here)
 
 *Note: There is a JVM versioning inconsistency currently that causes this script to fail for order-service and open-api with the current state of develop. Hotfixes are currently in place and awaiting a merge. Be advised
 

--- a/README.md
+++ b/README.md
@@ -49,3 +49,28 @@
 
 This was put together in a few hours.  
 Some shortcomings of this proxy server is that redirects don't seem to be working properly.
+
+
+## Script Automation
+A command line (cmd) script exists to run conveniently run the microservices along with the proxy - `stacklaunch`
+It currently takes up to five arguments including: `restaurant`, `account`, `order`, `search`, and `swagger`
+
+Providing no arguments will default to opening all services, but if arguments are provided only those services will run.
+Each service will open in it's own window for tracking and debugging (and because its kind of the only way for this simple solution to work) - so not providing the specific services you want to run may be annoying.
+
+This command needs to be made from the reverse-proxy folder, and relies on all of the projects to be reflective of the github organization with default directory names as would be pulled from github. The name of the root folder is inconsequential
+
+Example:
+
+InTheBytes
+|---account-service
+|---order-service
+|---search-service
+|---restaurant-manage-service
+|---open-api-since
+|---reverse-proxy (call command here)
+
+*Note: There is a JVM versioning inconsistency currently that causes this script to fail for order-service and open-api with the current state of develop. Hotfixes are currently in place and awaiting a merge. Be advised
+
+### Possible Changes
+It would be nice to also have a script that closed all of them. But in the spirit of this repository, only patchy fix-it code is allowed here.

--- a/config.json
+++ b/config.json
@@ -1,8 +1,8 @@
 {
-	"baseUrl": "https://stacklunch.com",
+	"baseUrl": "https://admin.stacklunch.com",
 	"port": "5050",
 	"localUrl": "http://localhost",
-	"localPort": 3000,
+	"localPort": 4200,
 	"routeTable": [
 		{
 			"port": 8081,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,60 +1,8 @@
 {
   "name": "reverseproxy",
   "version": "1.0.0",
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "requires": true,
-  "packages": {
-    "": {
-      "version": "1.0.0",
-      "license": "ISC",
-      "dependencies": {
-        "follow-redirects": "^1.14.1",
-        "http-proxy": "^1.18.1"
-      }
-    },
-    "node_modules/eventemitter3": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
-    },
-    "node_modules/follow-redirects": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.1.tgz",
-      "integrity": "sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/http-proxy": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
-      "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
-      "dependencies": {
-        "eventemitter3": "^4.0.0",
-        "follow-redirects": "^1.0.0",
-        "requires-port": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/requires-port": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
-    }
-  },
   "dependencies": {
     "eventemitter3": {
       "version": "4.0.7",

--- a/stacklaunch.cmd
+++ b/stacklaunch.cmd
@@ -9,7 +9,6 @@ if ["%~1"]==[""] (
 	call :Check %~4
 	call :Check %~5
 )
-cd reverse-proxy
 npm start
 setlocal
 exit /B 0
@@ -54,6 +53,6 @@ exit /b 0
 
 :Launch
 setlocal
-start cmd.exe /k "cd ..\%~1 & mvn clean package & java -jar -Dserver.port=%~2 target\%~3-0.0.1-SNAPSHOT.jar"
+start cmd.exe /k "cd ..\%~1 & mvn clean package & java -jar -Dserver.port=%~2 -Dspring.datasource.maxActive=1 target\%~3-0.0.1-SNAPSHOT.jar"
 endlocal
 exit /b 0

--- a/stacklaunch.cmd
+++ b/stacklaunch.cmd
@@ -1,0 +1,59 @@
+@echo off
+setlocal
+if ["%~1"]==[""] (
+	call :All
+) else (
+	call :Check %~1
+	call :Check %~2
+	call :Check %~3
+	call :Check %~4
+	call :Check %~5
+)
+cd reverse-proxy
+npm start
+setlocal
+exit /B 0
+
+:Check
+setlocal
+if ["%~1"]==["restaurant"] (call :Restaurant)
+if ["%~1"]==["account"] (call :Account)
+if ["%~1"]==["search"] (call :Search)
+if ["%~1"]==["order"] (call :Order)
+if ["%~1"]==["swagger"] (call :Swagger)
+endlocal
+exit /b 0
+
+:All
+call :Restaurant
+call :Account
+call :Order
+call :Search
+call :Swagger
+exit /b 0
+
+:Restaurant
+call :Launch restaurant-manage-service 8083 restaurantmanager
+exit /b 0
+
+:Account
+call :Launch account-service 8082 accountservice
+exit /b 0
+
+:Order
+call :Launch order-service 8084 orderservice
+exit /b 0
+
+:Search
+call :Launch search-service 8081 searchservice
+exit /b 0
+
+:Swagger
+call :Launch open-api-single 8085 openapi
+exit /b 0
+
+:Launch
+setlocal
+start cmd.exe /k "cd ..\%~1 & mvn clean package & java -jar -Dserver.port=%~2 target\%~3-0.0.1-SNAPSHOT.jar"
+endlocal
+exit /b 0


### PR DESCRIPTION
The script to automate running the spring microservices you need without needing to go through each one and establish server port arguments in an IDE. A cmd script, so must be run in command line - but very easy and intuitive to run.

Small glitch: on my machine, it does not work for order-service and open-apiwhile the java version is set to eleven. This jvm issue will hopefully be fixed shortly.